### PR TITLE
Fix full size child button overlap 

### DIFF
--- a/lib/unicorndial.dart
+++ b/lib/unicorndial.dart
@@ -237,9 +237,9 @@ class _UnicornDialer extends State<UnicornDialer>
         return Positioned(
           right: widget.orientation == UnicornOrientation.VERTICAL
               ? widget.childButtons[index].currentButton.mini ? 4.0 : 0.0
-              : ((widget.childButtons.length - index) * 55.0) + 15,
+              : ((widget.childButtons.length - index) * (widget.childButtons[index].currentButton.mini ? 55.0 : 70.0)) + 15,
           bottom: widget.orientation == UnicornOrientation.VERTICAL
-              ? ((widget.childButtons.length - index) * 55.0) + 15
+              ? ((widget.childButtons.length - index) * (widget.childButtons[index].currentButton.mini ? 55.0 : 70.0)) + 15
               : 8.0,
           child: Row(children: [
             ScaleTransition(


### PR DESCRIPTION
https://github.com/tiagojencmartins/unicornspeeddial/issues/21

Did not consider unequal size between child buttons.
Default distance spacing of full size button is 70 and you can modify it.
Thank you for your amazing work.
