### PR TITLE
Able to use Widget instead Icon types

### DIFF
--- a/lib/unicorndial.dart
+++ b/lib/unicorndial.dart
@@ -62,8 +62,8 @@ class UnicornButton extends FloatingActionButton {
 
 class UnicornDialer extends StatefulWidget {
   final int orientation;
-  final Icon parentButton;
-  final Icon finalButtonIcon;
+  final Widget parentButton;
+  final Widget finalButtonIcon;
   final bool hasBackground;
   final Color parentButtonBackground;
   final List<UnicornButton> childButtons;
@@ -178,12 +178,11 @@ class _UnicornDialer extends State<UnicornDialer>
                           transform: new Matrix4.rotationZ(
                               this._animationController.value * 0.8),
                           alignment: FractionalOffset.center,
-                          child: new Icon(
-                              this._animationController.isDismissed
-                                  ? widget.parentButton.icon
+                          child: this._animationController.isDismissed
+				  ? widget.parentButton
                                   : widget.finalButtonIcon == null
-                                  ? Icons.close
-                                  : widget.finalButtonIcon.icon),
+                                  ? new Icon(Icons.close)
+			          : widget.finalButtonIcon
                         );
                       })));
         });


### PR DESCRIPTION
Task: Able to use IconImage instead Icon types. Flexibile change of color and size of parentButton and FinalButton.
Decision: 
1. Minor changes of parameters declaration with change Icon to WIdget class type 
2. Change of animation for parent button when called FloatingActionButton for rendering of parent button
Result: 
1. Able use ani Icon images for FAB
2. Possibilities change of color, size and other setting for icons which used for parent button
Example:

   return UnicornDialer(
            parentButtonBackground: Colors.white,
            orientation: UnicornOrientation.VERTICAL,
            parentButton: ImageIcon(
                        AssetImage("images/icons/creaz nuovi contenuti.png"),
                        size: 40,
                        color: Colors.black,
            ),
            finalButtonIcon: ImageIcon(
                        AssetImage("images/icons/x cancella.png"),
                        size: 40,
                        color: Colors.black,
            ),
            childButtons: childButtons);