### PR TITLE
Removed closing on build, prevents auto close.

### DIFF
--- a/lib/unicorndial.dart
+++ b/lib/unicorndial.dart
@@ -130,7 +130,6 @@ class _UnicornDialer extends State<UnicornDialer>
 
   @override
   Widget build(BuildContext context) {
-    this._animationController.reverse();
 
     var hasChildButtons =
         widget.childButtons != null && widget.childButtons.length > 0;


### PR DESCRIPTION
Removing `this._animationController.reverse();` prevents the widget from auto closing when the widget gets rebuild.